### PR TITLE
Properly sanitize job names before passing to AWS Batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+* Correct sanitation of job names which previously blocked creation of class based batch jobs
+
 ## v0.2.0 (2017-04-07)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,11 @@
       "LukeWaite\\LaravelQueueAwsBatch\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      ":vendor\\:package_name\\": "tests"
+    }
+  },
   "require": {
     "illuminate/support": "~5.1.0",
     "aws/aws-sdk-php": "^3.20.6"

--- a/src/Queues/BatchQueue.php
+++ b/src/Queues/BatchQueue.php
@@ -63,7 +63,7 @@ class BatchQueue extends DatabaseQueue
     {
         if (is_object($job)) {
             return method_exists($job, 'displayName')
-                ? $job->displayName() : get_class($job);
+                ? $job->displayName() : str_replace('\\', '_', (string)get_class($job));
         } else {
             return is_string($job) ? explode('@', $job)[0] : null;
         }

--- a/tests/BatchJobTest.php
+++ b/tests/BatchJobTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LukeWaite\LaravelQueueAwsBatch\Tests;
+
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
Fixes #21