### PR TITLE
fix: Correctly set the queue on construction of a BatchJob

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "require-dev": {
     "mockery/mockery": "^0.9.6",
-    "laravel/framework": ">5.1.0 <5.4",
+    "laravel/framework": ">5.1.0 <5.2",
     "phpunit/phpunit": "~4.8",
     "squizlabs/php_codesniffer": "^2.8",
     "scrutinizer/ocular": "^1.3"

--- a/src/Console/QueueWorkBatchCommand.php
+++ b/src/Console/QueueWorkBatchCommand.php
@@ -53,6 +53,12 @@ class QueueWorkBatchCommand extends Command
         }
     }
 
+    /**
+     * @return array|null
+     * @throws JobNotFoundException
+     * @throws UnsupportedException
+     * @throws \Throwable
+     */
     protected function runJob()
     {
         $maxTries = $this->option('tries');
@@ -68,7 +74,7 @@ class QueueWorkBatchCommand extends Command
             throw new UnsupportedException('queue:work-batch can only be run on batch queues');
         }
 
-        $job = $connection->getJobById($jobId, $connectionName);
+        $job = $connection->getJobById($jobId);
 
         // If we're able to pull a job off of the stack, we will process it and
         // then immediately return back out.

--- a/src/Queues/BatchQueue.php
+++ b/src/Queues/BatchQueue.php
@@ -94,7 +94,12 @@ class BatchQueue extends DatabaseQueue
         return $jobId;
     }
 
-    public function getJobById($id, $queue)
+    /**
+     * @param $id
+     * @return BatchJob
+     * @throws JobNotFoundException
+     */
+    public function getJobById($id)
     {
         $job = $this->database->table($this->table)->where('id', $id)->first();
         if (!isset($job)) {
@@ -105,7 +110,7 @@ class BatchQueue extends DatabaseQueue
             $this->container,
             $this,
             $job,
-            $queue
+            $job->queue
         );
     }
 

--- a/tests/BatchQueueTest.php
+++ b/tests/BatchQueueTest.php
@@ -75,8 +75,10 @@ class BatchQueueTest extends TestCase
         $query->shouldReceive('where')->once()->with('id', 1)->andReturn($results = m::mock('StdClass'));
         $results->shouldReceive('first')->once()->andReturn($queryResult = m::mock('StdClass'));
         $queryResult->attempts = 0;
+        $queryResult->queue = 'defaultQueue';
 
-        $this->queue->getJobById(1, 'default');
+        $job = $this->queue->getJobById(1, 'default');
+        $this->assertEquals('defaultQueue', $job->getQueue());
     }
 
     public function testRelease()


### PR DESCRIPTION
Setting the queue correctly on the BatchJob allows failing jobs to be pushed
onto the `failed_jobs` table with the correct queue, which allows them to be
retried onto the correct queue.